### PR TITLE
Fix Stack's implementation and Vector

### DIFF
--- a/src/DataStructure/Stack.hpp
+++ b/src/DataStructure/Stack.hpp
@@ -1,29 +1,47 @@
 #pragma once
 
+#include "IStack.hpp"
 #include "Vector.hpp"
 
 namespace dsa {
     template<typename T>
-    class Stack : public Vector<T> {
+    class Stack : public IStack<T> {
+    private:
+        Vector<T> *m_vector;
 
     public:
+        Stack() {
+            m_vector = new Vector<T>;
+        };
+
+        ~Stack() {
+            delete m_vector;
+            m_vector = nullptr;
+        };
+
         void push(T const &e);
         T    pop();
         T   &top();
+        bool isEmpty();
     };
 
     template<typename T>
     void Stack<T>::push(const T &e) {
-        this->insert(this->size(), e);
+        m_vector->insert(m_vector->size() - 1, e);
     }
 
     template<typename T>
     T Stack<T>::pop() {
-        return this->remove(this->size() - 1);
+        return m_vector->remove(m_vector->size() - 1);
     }
 
     template<typename T>
     T &Stack<T>::top() {
-        return (*this)[this->size() - 1];
+        return (*m_vector)[m_vector->size() - 1];
+    }
+
+    template<typename T>
+    bool Stack<T>::isEmpty() {
+        return m_vector->size() == 0;
     }
 }

--- a/src/DataStructure/Stack.hpp
+++ b/src/DataStructure/Stack.hpp
@@ -27,12 +27,12 @@ namespace dsa {
 
     template<typename T>
     void Stack<T>::push(const T &e) {
-        m_vector->insert(m_vector->size() - 1, e);
+        m_vector->push_back(e);
     }
 
     template<typename T>
     T Stack<T>::pop() {
-        return m_vector->remove(m_vector->size() - 1);
+        return m_vector->pop_back();
     }
 
     template<typename T>

--- a/src/DataStructure/Vector.hpp
+++ b/src/DataStructure/Vector.hpp
@@ -84,6 +84,9 @@ namespace dsa {
             m_elem = nullptr;
         }
 
+        void push_back(T const &e);
+        T    pop_back();
+
         // Read-Only interface
         bool isEmpty() const;
         Rank size() const;
@@ -165,6 +168,25 @@ namespace dsa {
 
         delete[] oldElem;
         oldElem = nullptr;
+    }
+
+    template<typename T>
+    void Vector<T>::push_back(T const &e) {
+        expand();
+        if (m_size == 0) {
+            m_elem[0] = e;
+            m_size++;
+        } else {
+            insert(m_size, e);
+        }
+    }
+
+    template<typename T>
+    T Vector<T>::pop_back() {
+        if (m_size == 0) {
+            return *(new T);
+        }
+        return remove(m_size - 1);
     }
 
     template<typename T>

--- a/src/DataStructure/Vector.hpp
+++ b/src/DataStructure/Vector.hpp
@@ -41,8 +41,6 @@ namespace dsa {
         void shrink();
 
     public:
-        Vector() = default;
-
         Vector(std::initializer_list<T> list) {
             m_size = list.size();
             m_capacity = m_size;
@@ -54,7 +52,7 @@ namespace dsa {
             }
         }
 
-        explicit Vector(Rank c = DEFAULT_CAPACITY, Rank s = 0, T v = 0) {
+        Vector(Rank c = DEFAULT_CAPACITY, Rank s = 0, T v = 0) {
             m_size = 0;
             m_capacity = c;
             m_elem = new T[m_capacity];


### PR DESCRIPTION
## Vector

- [x] 移除`Vector`默认构造以避免与自定义构造函数冲突
- [x] 添加公共接口方法 `push_back` `pop_back`

## Stack

- [x] 改`Stack`继承`Vector`为组合，方法接口继承`IStack`
- [x] 修改Stack接口实现
  - [x] `push` 改为直接调用`Vector.push_back`
  - [x] `pop` 改为直接调用`Vector.pop_back`
