### PR TITLE
fix(tree): correct some errors and omissions (#38)

### DIFF
--- a/src/DataStructure/BinTree.hpp
+++ b/src/DataStructure/BinTree.hpp
@@ -10,8 +10,8 @@ namespace dsa {
         using Node = BinTreeNode<T> *;
 
     protected:
-        size_type m_size;
-        Node      m_root;
+        size_type m_size{};
+        Node      m_root{};
 
         virtual size_type updateHeight(Node x) {
             x->m_height = 1 + std::max(stature(x->m_left), stature(x->m_right));
@@ -26,8 +26,9 @@ namespace dsa {
         }
 
     public:
-        BinTree() : BinTree(1ul, new BinTreeNode<T>()) {
+        BinTree() : BinTree(1l, new BinTreeNode<T>()) {
         }
+
         BinTree(size_type size, Node root) : m_size(size), m_root(root) {
         }
 
@@ -44,9 +45,17 @@ namespace dsa {
             return m_root;
         }
 
-        Node parent();
-        Node firstChild();
-        Node nextSibling();
+        Node parent() {
+            return nullptr;
+        }
+
+        Node firstChild() {
+            return nullptr;
+        }
+
+        Node nextSibling() {
+            return nullptr;
+        }
 
         Node insert(Node x, T const &data) {
             m_size++;
@@ -55,9 +64,11 @@ namespace dsa {
             return x->m_right;
         }
 
-        Node remove(Node x);
+        Node remove(Node x) {
+            return nullptr;
+        }
 
-        static size_type stature(Node p) {
+        static inline size_type stature(Node p) {
             if (p == nullptr) {
                 return -1;
             }

--- a/src/DataStructure/BinTreeNode.hpp
+++ b/src/DataStructure/BinTreeNode.hpp
@@ -3,7 +3,6 @@
 #include "AutoHeader.hpp"
 #include "Queue.hpp"
 #include "Stack.hpp"
-#include <cstdint>
 
 namespace dsa {
     template<class T>
@@ -31,14 +30,14 @@ namespace dsa {
 
     template<class T>
     struct BinTreeNode {
-        T         m_data;
-        size_type m_height;
+        T         m_data{};
+        size_type m_height{};
 
         BinTreeNode<T> *m_parent;
         BinTreeNode<T> *m_left;
         BinTreeNode<T> *m_right;
 
-        BinTreeNode() : BinTreeNode(0ul, 0ul, nullptr, nullptr, nullptr) {
+        BinTreeNode() : m_height(0l), m_parent(nullptr), m_left(nullptr), m_right(nullptr) {
         }
 
         BinTreeNode(T const &data, BinTreeNode<T> *parent)
@@ -53,8 +52,7 @@ namespace dsa {
           : m_data(data), m_height(height), m_parent(parent), m_left(left), m_right(right) {
         }
 
-        ~BinTreeNode() {
-        }
+        ~BinTreeNode() = default;
 
         BinTreeNode<T> *insertAsLeftChild(T const &e) {
             m_left = new BinTreeNode(e, this);
@@ -67,7 +65,9 @@ namespace dsa {
         }
 
         /// Return direct successor of current node(inorder)
-        BinTreeNode<T> *successor();
+        BinTreeNode<T> *successor() {
+            return nullptr;
+        }
 
         /// The total size of the subtree rooted at this node
         size_type size() const {


### PR DESCRIPTION
`BinTree`

- Add default initialization for all fields of `BinTree`
- Correct initialize default value of `m_size` in default constructor
- Add default implementations for methods not yet implemented
- Modify static methods `stature` to inline

`BinTreeNode`

- Delete unused header
- Add default initialization for some fields of `BinTreeNode`
- Modify the default constructor
- Declare destructor to default implementation for compiler
- Add default implementation for `successor`