### PR TITLE
fix(iterator): remove the inheritance of `std::iterator`

### DIFF
--- a/src/DataStructure/Iterator.hpp
+++ b/src/DataStructure/Iterator.hpp
@@ -4,14 +4,14 @@
 
 namespace dsa {
   template<class T>
-  class Iterator : public std::iterator<std::input_iterator_tag, T> {
+  class Iterator {
 public:
     /* An iterator class must declare(public) the following types */
     using difference_type = std::ptrdiff_t;
     using value_type = T;
     using pointer = T *;
     using reference = T &;
-    using iterator_category = std::output_iterator_tag;
+    using iterator_category = std::forward_iterator_tag;
 
 public:
     /* An iterator class must implement(public) the following operator overloads */


### PR DESCRIPTION
C++17 deprecate the usage of `std::iterator` in custom iterator, we can manually declare necessary type aliases to implement it.