### PR TITLE
Remove extra test case

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,5 +65,3 @@ function(dsa_test test_file)
     target_link_libraries("${test_target_name}" PRIVATE bitmap example Catch2::Catch2WithMain)
     add_test(NAME "${test_target_name}" COMMAND "${test_target_name}")
 endfunction(dsa_test)
-
-dsa_test("test/test_main.cpp")

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -7,7 +7,3 @@ main(int argc, const char **argv) {
 
   return result;
 }
-
-TEST_CASE("912-DSA Catch2 Test", "[912]") {
-  REQUIRE(1 + 1 == 2);
-}


### PR DESCRIPTION
The test case in `test_main.cpp`  is extra, removing it  is more clear.